### PR TITLE
validate rkom process ext id in rkom combinations

### DIFF
--- a/cognite/powerops/config.py
+++ b/cognite/powerops/config.py
@@ -798,8 +798,8 @@ class BootstrapConfig(BaseModel):
     market: MarketConfig
     watercourses: list[WatercourseConfig]
     time_series_mappings: list[TimeSeriesMapping]
-    rkom_bid_combination: Optional[list[RKOMBidCombinationConfig]] = None
     rkom_bid_process: list[RKOMBidProcessConfig]
+    rkom_bid_combination: Optional[list[RKOMBidCombinationConfig]] = None
     rkom_market: Optional[RkomMarketConfig] = None
     plant_time_series_mappings: list[PlantTimeSeriesMapping] = None
     generator_time_series_mappings: list[GeneratorTimeSeriesMapping] = None
@@ -817,6 +817,23 @@ class BootstrapConfig(BaseModel):
                 f"\nare duplicated."
             )
         return value
+
+    @root_validator(pre=False)
+    def rkom_process_ext_ids(cls, values):
+        for rkom_bid_config in values["rkom_bid_combination"]:
+            for external_id_to_validate in rkom_bid_config.rkom_bid_config_external_ids:
+                is_valid = any(
+                    external_id_to_validate == process_config.external_id
+                    for process_config in values["rkom_bid_process"]
+                )
+                if not is_valid:
+                    raise ValueError(
+                        f"Reference to rkom bid process config in rkom_bid_combination yaml is wrong for "
+                        f"{external_id_to_validate}. "
+                        f"Possible references are: {[config.external_id for config in values['rkom_bid_process']]}"
+                    )
+        return values
+
 
     @classmethod
     def from_yamls(cls, config_dir_path: Path) -> "BootstrapConfig":


### PR DESCRIPTION
## Description
Validate that references to rkom_bid_process ext ids in rkom_bid_combination yaml exists and are correctly formatted.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
