### PR TITLE
Optional kwargs to override settings

### DIFF
--- a/cognite/powerops/client/powerops_client.py
+++ b/cognite/powerops/client/powerops_client.py
@@ -41,7 +41,16 @@ class PowerOpsClient:
         self.workflow = DayaheadTriggerAPI(self.cdf, self.datasets.write_dataset_id, cogshop_version)
 
     @classmethod
-    def from_settings(cls, settings: Settings | None = None) -> PowerOpsClient:
+    def from_settings(
+        cls,
+        settings: Settings | None = None,
+        *,
+        config: ClientConfig | None = None,
+        read_dataset: str | None = None,
+        write_dataset: str | None = None,
+        cogshop_version: str | None = None,
+        monitor_dataset: str | None = None,
+    ) -> PowerOpsClient:
         """
         Create a PowerOpsClient from a Settings object.
 
@@ -51,18 +60,23 @@ class PowerOpsClient:
                 the environment. When loading the Settings object from the environment,
                 the environment variable `SETTINGS_FILES` is used to
                 specify which files to load. The default value is `settings.toml;.secrets.toml`.
+            config: The client config object. Optional, by default it is loaded from the settings object.
+            read_dataset: externalId of read data set. Optional, by default loaded from the settings object.
+            write_dataset: externalId of write data set. Optional, by default loaded from the settings object.
+            monitor_dataset: externalId of monitor data set. Optional, by default loaded from the settings object.
+            cogshop_version: tag for the "cog-shop" Docker image. Optional, by default loaded from the settings object.
 
         Returns:
             A PowerOpsClient object.
         """
         settings = settings or Settings()
 
-        client_config = get_client_config(settings.cognite)
+        client_config = config if config is not None else get_client_config(settings.cognite)
 
         return PowerOpsClient(
-            settings.powerops.read_dataset,
-            settings.powerops.write_dataset,
-            settings.powerops.cogshop_version,
             config=client_config,
-            monitor_dataset=settings.powerops.monitor_dataset,
+            read_dataset=read_dataset if read_dataset is not None else settings.powerops.read_dataset,
+            write_dataset=write_dataset if write_dataset is not None else settings.powerops.write_dataset,
+            monitor_dataset=monitor_dataset if monitor_dataset is not None else settings.powerops.monitor_dataset,
+            cogshop_version=cogshop_version if cogshop_version is not None else settings.powerops.cogshop_version,
         )


### PR DESCRIPTION
## Description

Added some optional kwargs kwargs to override values from settings on `PowerOpsClient.from_settings()`.
Need the ability to override client config in functions repo (when `CogniteClient` is provided by Cognite functions machinery).

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
