### PR TITLE
Add shared BidDoc container and updated DayAhead

### DIFF
--- a/cognite/powerops/resync/models/v2/dms/baseBids/containers.yaml
+++ b/cognite/powerops/resync/models/v2/dms/baseBids/containers.yaml
@@ -1,3 +1,71 @@
+- space: '{{model_space}}'
+  externalId: BidDocument
+  name: BidDocument
+  usedFor: node
+  properties:
+    name:
+      type:
+        list: false
+        collation: ucs_basic
+        type: text
+      name: name
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+    date:
+      type:
+        list: false
+        type: date
+      name: date
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+    startCalculation:
+      type:
+        list: false
+        type: timestamp
+      name: startCalculation
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+    endCalculation:
+      type:
+        list: false
+        type: timestamp
+      name: endCalculation
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+    isComplete:
+      type:
+        list: false
+        type: boolean
+      name: isCompleted
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+    alerts:
+      type:
+        container:
+          space: '{{model_space}}'
+          externalId: Alert
+        type: direct
+        list: true
+      name: alerts
+      description: null
+      nullable: true
+      autoIncrement: false
+      defaultValue: null
+  indexes:
+    date:
+      indexType: btree
+      properties:
+        - date
 - space: {{model_space}}
   externalId: Alert
   name: Alert

--- a/cognite/powerops/resync/models/v2/dms/dayAheadBids/containers.yaml
+++ b/cognite/powerops/resync/models/v2/dms/dayAheadBids/containers.yaml
@@ -3,87 +3,50 @@
   name: BidDocument
   usedFor: node
   properties:
-    name:
-      type:
-        list: false
-        collation: ucs_basic
-        type: text
-      nullable: true
-      autoIncrement: false
-      name: name
-      defaultValue: null
-      description: null
     method:
       type:
         container:
           space: {{model_space}}
           externalId: BidMethod
         type: direct
+        list: false
       nullable: true
       autoIncrement: false
       name: method
       defaultValue: null
-    date:
-      type:
-        list: false
-        type: date
-      nullable: true
-      autoIncrement: false
-      name: date
-      defaultValue: null
-      description: null
     total:
       type:
         container:
           space: {{model_space}}
           externalId: BidTable
         type: direct
+        list: false
       nullable: true
       autoIncrement: false
       name: total
       defaultValue: null
-    startCalculation:
+    partials:
       type:
-        list: false
-        type: timestamp
+        container:
+          space: {{model_space}}
+          externalId: BidTable
+        type: direct
+        list: true
       nullable: true
       autoIncrement: false
-      name: startCalculation
+      name: total
       defaultValue: null
-      description: null
-    endCalculation:
-      type:
-        list: false
-        type: timestamp
-      nullable: true
-      autoIncrement: false
-      name: endCalculation
-      defaultValue: null
-      description: null
-    isComplete:
-      type:
-        list: false
-        type: boolean
-      nullable: false
-      autoIncrement: false
-      name: isComplete
-      defaultValue: false
-      description: null
     priceArea:
       type:
         container:
           space: {{model_space}}
           externalId: PriceArea
         type: direct
+        list: false
       nullable: true
       autoIncrement: false
       name: priceArea
       defaultValue: null
-  indexes:
-    date:
-      indexType: btree
-      properties:
-        - date
 - space: {{model_space}}
   externalId: BidMethod
   name: BidMethod

--- a/cognite/powerops/resync/models/v2/dms/dayAheadBids/containers.yaml
+++ b/cognite/powerops/resync/models/v2/dms/dayAheadBids/containers.yaml
@@ -34,7 +34,7 @@
         list: true
       nullable: true
       autoIncrement: false
-      name: total
+      name: partials
       defaultValue: null
     priceArea:
       type:

--- a/cognite/powerops/resync/models/v2/dms/dayAheadBids/views.yaml
+++ b/cognite/powerops/resync/models/v2/dms/dayAheadBids/views.yaml
@@ -5,7 +5,7 @@
   properties:
     name:
       container:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: BidDocument
         type: container
       containerPropertyIdentifier: name
@@ -39,7 +39,7 @@
       description: null
     date:
       container:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: BidDocument
         type: container
       containerPropertyIdentifier: date
@@ -60,7 +60,7 @@
       description: null
     startCalculation:
       container:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: BidDocument
         type: container
       containerPropertyIdentifier: startCalculation
@@ -68,7 +68,7 @@
       description: null
     endCalculation:
       container:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: BidDocument
         type: container
       containerPropertyIdentifier: endCalculation
@@ -76,7 +76,7 @@
       description: null
     isComplete:
       container:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: BidDocument
         type: container
       containerPropertyIdentifier: isComplete
@@ -95,7 +95,7 @@
       name: partials
     alerts:
       type:
-        space: '{{model_space}}'
+        space: '{{shared_model_space}}'
         externalId: Bid.alerts
       source:
         space: '{{model_space}}'


### PR DESCRIPTION
## Description
Changes to DayAhead views and containers to reflect the addition of a shared BidDocument container.

Note, target branch is [POWEROPS-1909-Create-YAML-spec-files-for-DM-containers-and-views](https://github.com/cognitedata/power-ops-sdk/tree/POWEROPS-1909-Create-YAML-spec-files-for-DM-containers-and-views)

To check out what it looks like: https://cog-power-ops.fusion.cognite.com/power-ops-staging/data-models/power-ops-day-ahead-bids-v2/DayAheadBids/latest?cluster=bluefield.cognitedata.com&env=bluefield (I'll delete everything in the space afterwards - just to show it works)

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
