### PR TITLE
change field type on the scenario container

### DIFF
--- a/cognite/powerops/custom_modules/power_model_v1/data_models/containers/Scenario.container.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/containers/Scenario.container.yaml
@@ -75,7 +75,7 @@ properties:
   shopStart:
     type:
       list: false
-      type: date
+      type: timestamp
     nullable: true
     autoIncrement: false
     name: shopStart
@@ -83,7 +83,7 @@ properties:
   shopEnd:
     type:
       list: false
-      type: date
+      type: timestamp
     nullable: true
     autoIncrement: false
     name: shopEnd


### PR DESCRIPTION
## Description

`shop_start` and `shop_end` need to be `timestamp` instead of `date`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
