### PR TITLE
add method to ShopPartialBidCalculationInput

### DIFF
--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/ShopPartialBidCalculationInput.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/ShopPartialBidCalculationInput.view.yaml
@@ -27,6 +27,19 @@ implements:
   type: view
 version: '{{version}}'
 properties:
+  method:
+    container:
+      space: '{{powerops_models}}'
+      externalId: BidConfiguration
+      type: container
+    containerPropertyIdentifier: method
+    name: method
+    description: The bid method related to the bid configuration
+    source:
+      space: '{{powerops_models}}'
+      externalId: BidMethodSHOPMultiScenario
+      version: '{{version}}'
+      type: view
   plant:
     container:
       space: '{{powerops_models}}'


### PR DESCRIPTION
## Description
Method needs to be a property in the ShopPartialBidCalculationInput object.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
