### PR TITLE
TotalBidMatrixCalculationInput suggestions

### DIFF
--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/bid_matrix/1-interface.BidMatrix.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/bid_matrix/1-interface.BidMatrix.view.yaml
@@ -29,6 +29,14 @@ properties:
       type: container
     containerPropertyIdentifier: matrix
     name: matrix
+  addSteps:
+    container:
+      space: '{{powerops_models}}'
+      externalId: FunctionData
+      type: container
+    containerPropertyIdentifier: flag
+    name: addSteps
+    description: Whether or not the steep volume steps within one price step size are enabled
   assetType:
     container:
       space: "{{powerops_models}}"

--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/ShopPartialBidCalculationInput.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/ShopPartialBidCalculationInput.view.yaml
@@ -66,14 +66,14 @@ properties:
       externalId: MarketConfiguration
       version: '{{version}}'
       type: view
-  stepEnabled:
+  addSteps:
     container:
       space: '{{powerops_models}}'
       externalId: FunctionData
       type: container
     containerPropertyIdentifier: flag
-    name: stepEnabled
-    description: Whether the step is enabled or not
+    name: addSteps
+    description: Whether or not the steep volume steps within one price step size are enabled
   bidDate:
     container:
       space: '{{powerops_models}}'

--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TotalBidMatrixCalculationInput.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TotalBidMatrixCalculationInput.view.yaml
@@ -53,18 +53,6 @@ properties:
       externalId: MarketConfiguration
       version: '{{version}}'
       type: view
-  priceArea:
-    container:
-      space: "{{powerops_models}}"
-      externalId: BidDocument
-      type: container
-    containerPropertyIdentifier: priceArea
-    name: priceArea
-    source:
-      space: "{{powerops_models}}"
-      externalId: PriceArea
-      version: "{{version}}"
-      type: view
   bidDate:
     container:
       space: '{{powerops_models}}'
@@ -73,11 +61,3 @@ properties:
     containerPropertyIdentifier: date1
     name: bidDate
     description: The bid date
-  addSteps:
-    container:
-      space: '{{powerops_models}}'
-      externalId: FunctionData
-      type: container
-    containerPropertyIdentifier: flag
-    name: addSteps
-    description: Whether or not the steep volume steps within one price step size are enabled

--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TotalBidMatrixCalculationInput.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TotalBidMatrixCalculationInput.view.yaml
@@ -40,3 +40,44 @@ properties:
     name: partialBidMatrices
     description: The partial bid matrices that are used to calculate the total bid matrix.
     connectionType: multi_edge_connection
+  marketConfiguration:
+    container:
+      space: '{{powerops_models}}'
+      externalId: FunctionData
+      type: container
+    containerPropertyIdentifier: direct2
+    name: marketConfiguration
+    description: The market configuration to be used to generate the total bid matrix
+    source:
+      space: '{{powerops_models}}'
+      externalId: MarketConfiguration
+      version: '{{version}}'
+      type: view
+  priceArea:
+    container:
+      space: "{{powerops_models}}"
+      externalId: BidDocument
+      type: container
+    containerPropertyIdentifier: priceArea
+    name: priceArea
+    source:
+      space: "{{powerops_models}}"
+      externalId: PriceArea
+      version: "{{version}}"
+      type: view
+  bidDate:
+    container:
+      space: '{{powerops_models}}'
+      externalId: FunctionData
+      type: container
+    containerPropertyIdentifier: date1
+    name: bidDate
+    description: The bid date
+  addSteps:
+    container:
+      space: '{{powerops_models}}'
+      externalId: FunctionData
+      type: container
+    containerPropertyIdentifier: flag
+    name: addSteps
+    description: Whether or not the steep volume steps within one price step size are enabled


### PR DESCRIPTION
## Description
I added add-steps, market-configuration, and bid-date to the input to the total bid matrix calculation.
I also added price-area, however, it was solely used in the external ID of the created total bid matrix. So do we really need price-area as an input?

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
