### PR TITLE
change property time to timestamp in order to get datetime object and…

### DIFF
--- a/cognite/powerops/custom_modules/power_model_v1/data_models/containers/Case.container.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/containers/Case.container.yaml
@@ -53,7 +53,7 @@ properties:
   startTime:
     type:
       list: false
-      type: date
+      type: timestamp
     nullable: true
     autoIncrement: false
     name: startTime
@@ -61,7 +61,7 @@ properties:
   endTime:
     type:
       list: false
-      type: date
+      type: timestamp
     nullable: true
     autoIncrement: false
     name: endTime

--- a/cognite/powerops/custom_modules/power_model_v1/data_models/containers/FunctionData.container.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/containers/FunctionData.container.yaml
@@ -38,13 +38,20 @@ properties:
     nullable: true
     autoIncrement: false
     name: date2
-  date3:
+  timestamp1:
     type:
       list: false
-      type: date
+      type: timestamp
     nullable: true
     autoIncrement: false
-    name: date3
+    name: timestamp1
+  timestamp2:
+    type:
+      list: false
+      type: timestamp
+    nullable: true
+    autoIncrement: false
+    name: timestamp2
   text1:
     type:
       list: false

--- a/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TaskDispatcherShopInput.view.yaml
+++ b/cognite/powerops/custom_modules/power_model_v1/data_models/views/function_inputs/TaskDispatcherShopInput.view.yaml
@@ -52,7 +52,7 @@ properties:
       space: '{{powerops_models}}'
       externalId: FunctionData
       type: container
-    containerPropertyIdentifier: date2
+    containerPropertyIdentifier: timestamp1
     name: shopStart
     description: The shop start date
   shopEnd:
@@ -60,6 +60,6 @@ properties:
       space: '{{powerops_models}}'
       externalId: FunctionData
       type: container
-    containerPropertyIdentifier: date3
+    containerPropertyIdentifier: timestamp2
     name: shopEnd
     description: The shop end date


### PR DESCRIPTION
… not just date

## Description
Might need some more changes to the TaskDispatcher view and also the PartialBidCalculations depending on how we are stitching together the output from `ShopPartialBidCalculationOutput` to `PartialPostProcessingInput` / `TotalBidMatrixCalculationInput`

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
