### PR TITLE
Fix: Change from outlet_level to outlet_line in data_model_configuration.yaml

### DIFF
--- a/tests/data/demo/v1/fornebu/data_model_configuration.yaml
+++ b/tests/data/demo/v1/fornebu/data_model_configuration.yaml
@@ -68,7 +68,7 @@ plant_water_value_based:
     extraction_path: "model.plant.[name].main_loss.[0]"
   outlet_level:
     source_file: "files/model.yaml"
-    extraction_path: "model.plant.[name].outlet_level"
+    extraction_path: "model.plant.[name].outlet_line"
   production_max:
     source_file: "files/model.yaml"
     extraction_path: "model.plant.[name].p_max"


### PR DESCRIPTION
## Description
I noticed that outlet_level was None for all PlantWaterValueBased instances generated by resync. Checked the yaml file, and this is called "outlet_line" there, so we have to change this in data_model_configuration.yaml

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
