### PR TITLE
chore: update action version due to Node.js 16 actions being deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +26,6 @@ jobs:
           pre-commit run --all-files
 
   tests:
-    name: Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -63,7 +61,6 @@ jobs:
         run: poetry build
 
   build-docs:
-    name: Build docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,7 @@ jobs:
           pre-commit run --all-files
 
   tests:
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -61,6 +63,7 @@ jobs:
         run: poetry build
 
   build-docs:
+    name: Build docs
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -33,7 +33,7 @@ jobs:
     environment: CD
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +30,7 @@ jobs:
           pre-commit run --all-files
 
   test_and_release:
+    name: Test and Release
     runs-on: ubuntu-latest
     environment: CD
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ env:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +29,6 @@ jobs:
           pre-commit run --all-files
 
   test_and_release:
-    name: Test and Release
     runs-on: ubuntu-latest
     environment: CD
     steps:

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -11,7 +11,7 @@ on:
       - "tests/data/demo/v1/**.yml"
 
 jobs:
-  resync-plan:
+  resync-apply:
     name: Resync Apply "v1" to CDF project ${{ vars.PROJECT }}
 
     environment:
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
 
@@ -34,7 +34,7 @@ jobs:
           poetry config virtualenvs.create false
           poetry install
 
-      - name: Run resync plan
+      - name: Run resync apply
         env:
           SETTINGS__COGNITE__CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           SETTINGS__COGNITE__CLIENT_ID: ${{ vars.CLIENT_ID }}

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -10,6 +10,9 @@ on:
       - "tests/data/demo/v1/**.yaml"
       - "tests/data/demo/v1/**.yml"
 
+env:
+  CONFIGURATION_FILE: "tests/data/demo/v1/resync_configuration.yaml"
+
 jobs:
   resync-apply:
     name: Resync Apply "v1" to CDF project ${{ vars.PROJECT }}
@@ -42,4 +45,4 @@ jobs:
           SETTINGS__COGNITE__LOGIN_FLOW: "client_credentials"
         run: |
           echo Running resync apply in CDF environment $SETTINGS__COGNITE__PROJECT
-          powerops apply_v1 tests/data/demo/v1/resync_configuration.yaml
+          powerops apply_v1 $CONFIGURATION_FILE

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/resync-plan.yaml
+++ b/.github/workflows/resync-plan.yaml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
 

--- a/.github/workflows/resync-plan.yaml
+++ b/.github/workflows/resync-plan.yaml
@@ -21,8 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: main
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/resync-plan.yaml
+++ b/.github/workflows/resync-plan.yaml
@@ -10,6 +10,9 @@ on:
       - "tests/data/demo/v1/**.yaml"
       - "tests/data/demo/v1/**.yml"
 
+env:
+  CONFIGURATION_FILE: "tests/data/demo/v1/resync_configuration.yaml"
+
 jobs:
   resync-plan:
     name: Resync Plan "v1" to CDF project ${{ vars.PROJECT }}
@@ -42,4 +45,4 @@ jobs:
           SETTINGS__COGNITE__LOGIN_FLOW: "client_credentials"
         run: |
           echo Running resync plan in CDF environment $SETTINGS__COGNITE__PROJECT
-          powerops plan_v1 tests/data/demo/v1/resync_configuration.yaml
+          powerops plan_v1 $CONFIGURATION_FILE


### PR DESCRIPTION
## Description
Update action versions to resolve warning about [Node.js 16 being deprecated](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).
