### PR TITLE
Resync fix partial wvbbg lund step power asset

### DIFF
--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -1,14 +1,15 @@
 name: Resync Apply "v1"
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "cognite/powerops/resync/v1/**.py"
-      - "cognite/powerops/cli.py"
-      - "tests/data/demo/v1/**.yaml"
-      - "tests/data/demo/v1/**.yml"
+  workflow_dispatch
+  #push:
+  #  branches:
+  #    - main
+  #  paths:
+  #    - "cognite/powerops/resync/v1/**.py"
+  #    - "cognite/powerops/cli.py"
+  #    - "tests/data/demo/v1/**.yaml"
+  #    - "tests/data/demo/v1/**.yml"
 
 env:
   CONFIGURATION_FILE: "tests/data/demo/v1/resync_configuration.yaml"

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -1,6 +1,7 @@
 name: Resync Apply "v1"
 
-on: workflow_dispatch
+on:
+    workflow_dispatch:
 #push:
 #  branches:
 #    - main

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -1,15 +1,14 @@
 name: Resync Apply "v1"
 
-on:
-  workflow_dispatch
-  #push:
-  #  branches:
-  #    - main
-  #  paths:
-  #    - "cognite/powerops/resync/v1/**.py"
-  #    - "cognite/powerops/cli.py"
-  #    - "tests/data/demo/v1/**.yaml"
-  #    - "tests/data/demo/v1/**.yml"
+on: workflow_dispatch
+#push:
+#  branches:
+#    - main
+#  paths:
+#    - "cognite/powerops/resync/v1/**.py"
+#    - "cognite/powerops/cli.py"
+#    - "tests/data/demo/v1/**.yaml"
+#    - "tests/data/demo/v1/**.yml"
 
 env:
   CONFIGURATION_FILE: "tests/data/demo/v1/resync_configuration.yaml"

--- a/.github/workflows/resync-apply.yaml
+++ b/.github/workflows/resync-apply.yaml
@@ -1,7 +1,7 @@
 name: Resync Apply "v1"
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 #push:
 #  branches:
 #    - main

--- a/tests/data/demo/v1/fornebu/water_value_based_partial_bid_configuration.yaml
+++ b/tests/data/demo/v1/fornebu/water_value_based_partial_bid_configuration.yaml
@@ -10,7 +10,7 @@
   add_steps: false
 - name: Plant Lund Step
   method: Water Value Based Bid Generation (WVBBG)
-  power_asset: "[external_id]plant_water_value_based_lund"
+  power_asset: "[name|type:PlantInformation]Lund"
   add_steps: true
 - name: Plant Dalby Step
   method: Water Value Based Bid Generation (WVBBG)


### PR DESCRIPTION
## Description
Resync: Partial bid config water_value_based_partial_bid_configuration_plant_lund_step was missing a power asset. This should fix that.
In addition, I am trying to turn off automatic resync apply v1 on merge to main

## Checklist:
- [ ] ~~Tests added/updated.~~
- [ ] ~~Documentation updated.~~
- [ ] ~~Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).~~
- [ ] ~~Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) per [semantic versioning](https://semver.org/).~~
