### PR TITLE
fix: missing env for toolkit deploy

### DIFF
--- a/.github/workflows/toolkit-deploy.yaml
+++ b/.github/workflows/toolkit-deploy.yaml
@@ -39,6 +39,7 @@ jobs:
         IDP_CLIENT_ID: ${{ vars.CLIENT_ID }}
         IDP_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
         IDP_TENANT_ID: ${{ vars.TENANT_ID }}
+        WF_TRIGGER_SECRET: ${{ secrets.WF_TRIGGER_SECRET }}
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Build modules
@@ -71,7 +72,6 @@ jobs:
           PROJECT: ${{ vars.PROJECT }}
           CLUSTER: ${{ vars.CLUSTER }}
           TENANT_ID: ${{ vars.TENANT_ID }}
-          WF_TRIGGER_SECRET: ${{ secrets.WF_TRIGGER_SECRET }}
         run: |
           echo Running resync plan in CDF environment $PROJECT
           powerops purge $CLIENT_CONFIG_FILE $CONFIGURATION_FILE


### PR DESCRIPTION
## Description
Switch missing env to the correct job in github action

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) and [_version.py](https://github.com/cognitedata/power-ops-sdk/blob/main/cognite/powerops/_version.py) per [semantic versioning](https://semver.org/). Version bump is not needed for resync or toolkit configuration changes as they do not affect the SDK itself.
