### PR TITLE
fix: missing configuration for 15 min bids

### DIFF
--- a/resync/fornebu/shop_based_partial_bid_configuration.yaml
+++ b/resync/fornebu/shop_based_partial_bid_configuration.yaml
@@ -320,3 +320,320 @@
   power_asset: "[external_id]plant_information_holen"
   add_steps: False
   scenario_set: "[name]Fornebu 20 scenarios"
+
+# 15 min test cases
+- name: 15 min Lund 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Lund 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Lund 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Lund 1
+  method: price independent
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Lund 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Lund 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Lund 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_lund"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Rull2 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Rull2 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Rull2 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Rull2 1
+  method: price independent
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Rull2 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Rull2 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Rull2 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_rull2"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Scott 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Scott 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Scott 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Scott 1
+  method: price independent
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Scott 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Scott 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Scott 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_scott"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Strand_krv 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Strand_krv 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Strand_krv 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Strand_krv 1
+  method: price independent
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Strand_krv 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Strand_krv 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Strand_krv 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_strand_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Dalby 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Dalby 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Dalby 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Dalby 1
+  method: price independent
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Dalby 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Dalby 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Dalby 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_dalby"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Landet 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Landet 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Landet 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Landet 1
+  method: price independent
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Landet 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Landet 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Landet 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_landet"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Rull1 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Rull1 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Rull1 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Rull1 1
+  method: price independent
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Rull1 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Rull1 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Rull1 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_rull1"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Lien_krv 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Lien_krv 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Lien_krv 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Lien_krv 1
+  method: price independent
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Lien_krv 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Lien_krv 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Lien_krv 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_lien_krv"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Holen 2 step
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Holen 3 step
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Holen 20 step
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: True
+  scenario_set: "[name]15 min Fornebu 20 scenarios"
+- name: 15 min Holen 1
+  method: price independent
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 1 scenario"
+- name: 15 min Holen 2
+  method: multi scenario 2
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 2 scenarios"
+- name: 15 min Holen 3
+  method: multi scenario 3
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 3 scenarios"
+- name: 15 min Holen 20
+  method: multi scenario 20
+  power_asset: "[external_id]plant_information_holen"
+  add_steps: False
+  scenario_set: "[name]15 min Fornebu 20 scenarios"

--- a/resync/fornebu/shop_scenario.yaml
+++ b/resync/fornebu/shop_scenario.yaml
@@ -233,6 +233,18 @@
     - "[name]market price"
     - "[name]plant production"
     - "[name]plant consumption"
+- name: "Fornebu price plus 200 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]default"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_200_first_24h"
+    - "[external_id]no2_sale_price_plus_200_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
 - name: "Fornebu price plus 2000 first 24h"
   model: "[name]Fornebu"
   commands: "[name|type:ShopCommands]default"
@@ -257,12 +269,266 @@
     - "[name]market price"
     - "[name]plant production"
     - "[name]plant consumption"
-- name: "Fornebu base 15 min test"
+
+# Temp 15 min scenarios for testing
+- name: "15 min Fornebu base"
   model: "[name]Fornebu"
   commands: "[name]default"
   time_resolution: "[name|type:ShopTimeResolution]15 min test"
   source: resync
   attribute_mappings_override: []
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 500 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_500_first_24h"
+    - "[external_id]no2_sale_price_minus_500_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 200 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_200_first_24h"
+    - "[external_id]no2_sale_price_minus_200_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 50 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_50_first_24h"
+    - "[external_id]no2_sale_price_minus_50_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 40 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_40_first_24h"
+    - "[external_id]no2_sale_price_minus_40_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 30 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_30_first_24h"
+    - "[external_id]no2_sale_price_minus_30_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 20 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_20_first_24h"
+    - "[external_id]no2_sale_price_minus_20_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 15 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_15_first_24h"
+    - "[external_id]no2_sale_price_minus_15_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 10 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_10_first_24h"
+    - "[external_id]no2_sale_price_minus_10_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price minus 5 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_minus_5_first_24h"
+    - "[external_id]no2_sale_price_minus_5_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 5 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_5_first_24h"
+    - "[external_id]no2_sale_price_plus_5_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 10 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_10_first_24h"
+    - "[external_id]no2_sale_price_plus_10_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 15 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_15_first_24h"
+    - "[external_id]no2_sale_price_plus_15_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 20 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_20_first_24h"
+    - "[external_id]no2_sale_price_plus_20_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 30 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_30_first_24h"
+    - "[external_id]no2_sale_price_plus_30_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 40 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_40_first_24h"
+    - "[external_id]no2_sale_price_plus_40_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 50 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_50_first_24h"
+    - "[external_id]no2_sale_price_plus_50_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 70 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_70_first_24h"
+    - "[external_id]no2_sale_price_plus_70_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 100 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_100_first_24h"
+    - "[external_id]no2_sale_price_plus_100_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 200 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_200_first_24h"
+    - "[external_id]no2_sale_price_plus_200_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price plus 2000 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_2000_first_24h"
+    - "[external_id]no2_sale_price_plus_2000_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
+- name: "15 min Fornebu price multiply 0 first 24h"
+  model: "[name]Fornebu"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]15 min test"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_multiply_0_first_24h"
+    - "[external_id]no2_sale_price_multiply_0_first_24h"
   output_definition:
     - "[name]market price"
     - "[name]plant production"

--- a/resync/fornebu/shop_scenario_set.yaml
+++ b/resync/fornebu/shop_scenario_set.yaml
@@ -46,8 +46,47 @@
     - "[name]Fornebu price plus 70 first 24h"
     - "[name]Fornebu price plus 100 first 24h"
     - "[name]Fornebu price plus 2000 first 24h"
-- name: Fornebu 1 scenario 15 min test
+
+# 15 min test cases
+- name: 15 min Fornebu 1 scenario
   start_specification: "[name]Default Start"
   end_specification: "[name]Default End"
   scenarios:
-    - "[name]Fornebu base 15 min test"
+    - "[name]15 min Fornebu base"
+- name: 15 min Fornebu 2 scenarios
+  start_specification: "[name]Default Start"
+  end_specification: "[name]Default End"
+  scenarios:
+    - "[name]15 min Fornebu base"
+    - "[name]15 min Fornebu price plus 200 first 24h"
+- name: 15 min Fornebu 3 scenarios
+  start_specification: "[name]Default Start"
+  end_specification: "[name]Default End"
+  scenarios:
+    - "[name|type:ShopScenario]15 min Fornebu price minus 200 first 24h"
+    - "[name]15 min Fornebu base"
+    - "[name]15 min Fornebu price plus 200 first 24h"
+- name: 15 min Fornebu 20 scenarios
+  start_specification: "[name]Default Start"
+  end_specification: "[name]Default End"
+  scenarios:
+    - "[name]15 min Fornebu price minus 500 first 24h"
+    - "[name]15 min Fornebu price multiply 0 first 24h"
+    - "[name]15 min Fornebu price minus 50 first 24h"
+    - "[name]15 min Fornebu price minus 40 first 24h"
+    - "[name]15 min Fornebu price minus 30 first 24h"
+    - "[name]15 min Fornebu price minus 20 first 24h"
+    - "[name]15 min Fornebu price minus 15 first 24h"
+    - "[name]15 min Fornebu price minus 10 first 24h"
+    - "[name]15 min Fornebu price minus 5 first 24h"
+    - "[name]15 min Fornebu base"
+    - "[name]15 min Fornebu price plus 5 first 24h"
+    - "[name]15 min Fornebu price plus 10 first 24h"
+    - "[name]15 min Fornebu price plus 15 first 24h"
+    - "[name]15 min Fornebu price plus 20 first 24h"
+    - "[name]15 min Fornebu price plus 30 first 24h"
+    - "[name]15 min Fornebu price plus 40 first 24h"
+    - "[name]15 min Fornebu price plus 50 first 24h"
+    - "[name]15 min Fornebu price plus 70 first 24h"
+    - "[name]15 min Fornebu price plus 100 first 24h"
+    - "[name]15 min Fornebu price plus 2000 first 24h"

--- a/resync/shared/bid_configuration_day_ahead.yaml
+++ b/resync/shared/bid_configuration_day_ahead.yaml
@@ -125,13 +125,15 @@
   bid_date_specification: "[name]Default BidDate"
   partials:
     - "[external_id]shop_based_partial_bid_configuration_sola_3"
+
+# 15 min test cases
 - name: 15 min Test Multi Scenario 3
   market_configuration: "[name]Nord Pool Day-Ahead 15 min"
   price_area: "[external_id]price_area_information_no2"
   bid_date_specification: "[name]Default BidDate"
   partials:
-    - "[external_id]shop_based_partial_bid_configuration_landet_3"
-    - "[external_id]shop_based_partial_bid_configuration_lund_3"
+    - "[external_id]shop_based_partial_bid_configuration_15_min_landet_3"
+    - "[external_id]shop_based_partial_bid_configuration_15_min_lund_3"
 - name: 15 min Test Water Value
   market_configuration: "[name]Nord Pool Day-Ahead 15 min"
   price_area: "[external_id]price_area_information_no2"
@@ -145,6 +147,6 @@
   bid_date_specification: "[name]Default BidDate"
   partials:
     - "[name|type:WaterValueBasedPartialBidConfiguration]Plant Scott Step"
-    - "[external_id]shop_based_partial_bid_configuration_lien_krv_3"
-    - "[external_id]shop_based_partial_bid_configuration_landet_2"
-    - "[external_id]shop_based_partial_bid_configuration_lund_3_step"
+    - "[external_id]shop_based_partial_bid_configuration_15_min_lien_krv_3"
+    - "[external_id]shop_based_partial_bid_configuration_15_min_landet_2"
+    - "[external_id]shop_based_partial_bid_configuration_15_min_lund_3_step"

--- a/resync/stavanger/shop_scenario.yaml
+++ b/resync/stavanger/shop_scenario.yaml
@@ -233,6 +233,18 @@
     - "[name]market price"
     - "[name]plant production"
     - "[name]plant consumption"
+- name: "Stavanger price plus 200 first 24h"
+  model: "[name]Stavanger"
+  commands: "[name|type:ShopCommands]default"
+  time_resolution: "[name|type:ShopTimeResolution]default"
+  source: resync
+  attribute_mappings_override:
+    - "[external_id]no2_buy_price_plus_200_first_24h"
+    - "[external_id]no2_sale_price_plus_200_first_24h"
+  output_definition:
+    - "[name]market price"
+    - "[name]plant production"
+    - "[name]plant consumption"
 - name: "Stavanger price plus 2000 first 24h"
   model: "[name]Stavanger"
   commands: "[name|type:ShopCommands]default"

--- a/toolkit/modules/resync/data_models/nodes/fornebu:ShopBasedPartialBidConfiguration.node.yaml
+++ b/toolkit/modules/resync/data_models/nodes/fornebu:ShopBasedPartialBidConfiguration.node.yaml
@@ -1,3 +1,1389 @@
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Dalby 1
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Dalby 2
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Dalby 20
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Dalby 20 step
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Dalby 2 step
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Dalby 3
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_dalby_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Dalby 3 step
+      powerAsset:
+        externalId: plant_information_dalby
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Holen 1
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Holen 2
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Holen 20
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Holen 20 step
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Holen 2 step
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Holen 3
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_holen_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Holen 3 step
+      powerAsset:
+        externalId: plant_information_holen
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Landet 1
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Landet 2
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Landet 20
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Landet 20 step
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Landet 2 step
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Landet 3
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_landet_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Landet 3 step
+      powerAsset:
+        externalId: plant_information_landet
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Lien_krv 1
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Lien_krv 2
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Lien_krv 20
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Lien_krv 20 step
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Lien_krv 2 step
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Lien_krv 3
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lien_krv_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Lien_krv 3 step
+      powerAsset:
+        externalId: plant_information_lien_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Lund 1
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Lund 2
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Lund 20
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Lund 20 step
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Lund 2 step
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Lund 3
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_lund_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Lund 3 step
+      powerAsset:
+        externalId: plant_information_lund
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Rull1 1
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Rull1 2
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Rull1 20
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Rull1 20 step
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Rull1 2 step
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Rull1 3
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull1_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Rull1 3 step
+      powerAsset:
+        externalId: plant_information_rull1
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Rull2 1
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Rull2 2
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Rull2 20
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Rull2 20 step
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Rull2 2 step
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Rull2 3
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_rull2_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Rull2 3 step
+      powerAsset:
+        externalId: plant_information_rull2
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Scott 1
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Scott 2
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Scott 20
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Scott 20 step
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Scott 2 step
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Scott 3
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_scott_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Scott 3 step
+      powerAsset:
+        externalId: plant_information_scott
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_1
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: price independent
+      name: 15 min Strand_krv 1
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_1_scenario
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_2
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 2
+      name: 15 min Strand_krv 2
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_20
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 20
+      name: 15 min Strand_krv 20
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_20_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 20
+      name: 15 min Strand_krv 20 step
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_2_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 2
+      name: 15 min Strand_krv 2 step
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_3
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: false
+      method: multi scenario 3
+      name: 15 min Strand_krv 3
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
+- externalId: shop_based_partial_bid_configuration_15_min_strand_krv_3_step
+  instanceType: node
+  sources:
+  - properties:
+      addSteps: true
+      method: multi scenario 3
+      name: 15 min Strand_krv 3 step
+      powerAsset:
+        externalId: plant_information_strand_krv
+        space: power_ops_instances
+      scenarioSet:
+        externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+        space: power_ops_instances
+    source:
+      externalId: ShopBasedPartialBidConfiguration
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopBasedPartialBidConfiguration
+    space: power_ops_types
 - externalId: shop_based_partial_bid_configuration_dalby_1
   instanceType: node
   sources:

--- a/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenario.edge.yaml
+++ b/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenario.edge.yaml
@@ -1,6 +1,1302 @@
 - endNode:
     externalId: shop_output_time_series_definition_market_price
     space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_base:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_base:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_base:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h:no2_buy_price_minus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h:no2_sale_price_minus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h:no2_buy_price_minus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h:no2_sale_price_minus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h:no2_buy_price_minus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h:no2_sale_price_minus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h:no2_buy_price_minus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h:no2_sale_price_minus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h:no2_buy_price_minus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h:no2_sale_price_minus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h:no2_buy_price_minus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h:no2_sale_price_minus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_500_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h:no2_buy_price_minus_500_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_500_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h:no2_sale_price_minus_500_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h:no2_buy_price_minus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h:no2_sale_price_minus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_minus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h:no2_buy_price_minus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_minus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h:no2_sale_price_minus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_multiply_0_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h:no2_buy_price_multiply_0_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_multiply_0_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h:no2_sale_price_multiply_0_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_100_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h:no2_buy_price_plus_100_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_100_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h:no2_sale_price_plus_100_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h:no2_buy_price_plus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h:no2_sale_price_plus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h:no2_buy_price_plus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h:no2_sale_price_plus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_2000_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h:no2_buy_price_plus_2000_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_2000_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h:no2_sale_price_plus_2000_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h:no2_buy_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h:no2_sale_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h:no2_buy_price_plus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h:no2_sale_price_plus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h:no2_buy_price_plus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h:no2_sale_price_plus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h:no2_buy_price_plus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h:no2_sale_price_plus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h:no2_buy_price_plus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h:no2_sale_price_plus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h:no2_buy_price_plus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h:no2_sale_price_plus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_70_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h:no2_buy_price_plus_70_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_70_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h:no2_sale_price_plus_70_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
   externalId: shop_scenario_fornebu_base:shop_output_time_series_definition_market_price
   instanceType: edge
   space: power_ops_instances
@@ -30,42 +1326,6 @@
   space: power_ops_instances
   startNode:
     externalId: shop_scenario_fornebu_base
-    space: power_ops_instances
-  type:
-    externalId: ShopOutputTimeSeriesDefinition
-    space: power_ops_types
-- endNode:
-    externalId: shop_output_time_series_definition_market_price
-    space: power_ops_instances
-  externalId: shop_scenario_fornebu_base_15_min_test:shop_output_time_series_definition_market_price
-  instanceType: edge
-  space: power_ops_instances
-  startNode:
-    externalId: shop_scenario_fornebu_base_15_min_test
-    space: power_ops_instances
-  type:
-    externalId: ShopOutputTimeSeriesDefinition
-    space: power_ops_types
-- endNode:
-    externalId: shop_output_time_series_definition_plant_consumption
-    space: power_ops_instances
-  externalId: shop_scenario_fornebu_base_15_min_test:shop_output_time_series_definition_plant_consumption
-  instanceType: edge
-  space: power_ops_instances
-  startNode:
-    externalId: shop_scenario_fornebu_base_15_min_test
-    space: power_ops_instances
-  type:
-    externalId: ShopOutputTimeSeriesDefinition
-    space: power_ops_types
-- endNode:
-    externalId: shop_output_time_series_definition_plant_production
-    space: power_ops_instances
-  externalId: shop_scenario_fornebu_base_15_min_test:shop_output_time_series_definition_plant_production
-  instanceType: edge
-  space: power_ops_instances
-  startNode:
-    externalId: shop_scenario_fornebu_base_15_min_test
     space: power_ops_instances
   type:
     externalId: ShopOutputTimeSeriesDefinition
@@ -906,6 +2166,66 @@
   space: power_ops_instances
   startNode:
     externalId: shop_scenario_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: no2_buy_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_fornebu_price_plus_200_first_24h:no2_buy_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_fornebu_price_plus_200_first_24h:no2_sale_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_fornebu_price_plus_200_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_fornebu_price_plus_200_first_24h
     space: power_ops_instances
   type:
     externalId: ShopOutputTimeSeriesDefinition

--- a/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenario.node.yaml
+++ b/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenario.node.yaml
@@ -1,3 +1,531 @@
+- externalId: shop_scenario_15_min_fornebu_base
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu base
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 10 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 15 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 200 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 20 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 30 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 40 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 500 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 50 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price minus 5 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price multiply 0 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 100 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 10 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 15 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 2000 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 200 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 20 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 30 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 40 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 50 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 5 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: 15 min Fornebu price plus 70 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_15_min_test
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
 - externalId: shop_scenario_fornebu_base
   instanceType: node
   sources:
@@ -12,30 +540,6 @@
       source: resync
       timeResolution:
         externalId: shop_time_resolution_default
-        space: power_ops_instances
-    source:
-      externalId: ShopScenario
-      space: power_ops_core
-      type: view
-      version: '1'
-  space: power_ops_instances
-  type:
-    externalId: ShopScenario
-    space: power_ops_types
-- externalId: shop_scenario_fornebu_base_15_min_test
-  instanceType: node
-  sources:
-  - properties:
-      commands:
-        externalId: shop_commands_default
-        space: power_ops_instances
-      model:
-        externalId: shop_model_fornebu
-        space: power_ops_instances
-      name: Fornebu base 15 min test
-      source: resync
-      timeResolution:
-        externalId: shop_time_resolution_15_min_test
         space: power_ops_instances
     source:
       externalId: ShopScenario
@@ -369,6 +873,30 @@
         externalId: shop_model_fornebu
         space: power_ops_instances
       name: Fornebu price plus 2000 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_default
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
+- externalId: shop_scenario_fornebu_price_plus_200_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_fornebu
+        space: power_ops_instances
+      name: Fornebu price plus 200 first 24h
       source: resync
       timeResolution:
         externalId: shop_time_resolution_default

--- a/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenarioSet.edge.yaml
+++ b/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenarioSet.edge.yaml
@@ -1,4 +1,316 @@
 - endNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_1_scenario:shop_scenario_15_min_fornebu_base
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_1_scenario
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_base
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_500_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_500_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_minus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_multiply_0_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_100_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_100_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_10_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_10_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_15_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_15_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_2000_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_20_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_20_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_30_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_30_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_40_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_40_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_50_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_50_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_5_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_5_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_70_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_20_scenarios:shop_scenario_15_min_fornebu_price_plus_70_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_20_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_2_scenarios:shop_scenario_15_min_fornebu_base
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_2_scenarios:shop_scenario_15_min_fornebu_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_base
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_3_scenarios:shop_scenario_15_min_fornebu_base
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_minus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_3_scenarios:shop_scenario_15_min_fornebu_price_minus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
+    externalId: shop_scenario_15_min_fornebu_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_set_15_min_fornebu_3_scenarios:shop_scenario_15_min_fornebu_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+    space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet.scenarios
+    space: power_ops_types
+- endNode:
     externalId: shop_scenario_fornebu_base
     space: power_ops_instances
   externalId: shop_scenario_set_fornebu_1_scenario:shop_scenario_fornebu_base
@@ -6,18 +318,6 @@
   space: power_ops_instances
   startNode:
     externalId: shop_scenario_set_fornebu_1_scenario
-    space: power_ops_instances
-  type:
-    externalId: ShopScenarioSet.scenarios
-    space: power_ops_types
-- endNode:
-    externalId: shop_scenario_fornebu_base_15_min_test
-    space: power_ops_instances
-  externalId: shop_scenario_set_fornebu_1_scenario_15_min_test:shop_scenario_fornebu_base_15_min_test
-  instanceType: edge
-  space: power_ops_instances
-  startNode:
-    externalId: shop_scenario_set_fornebu_1_scenario_15_min_test
     space: power_ops_instances
   type:
     externalId: ShopScenarioSet.scenarios

--- a/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenarioSet.node.yaml
+++ b/toolkit/modules/resync/data_models/nodes/fornebu:ShopScenarioSet.node.yaml
@@ -1,11 +1,11 @@
-- externalId: shop_scenario_set_fornebu_1_scenario
+- externalId: shop_scenario_set_15_min_fornebu_1_scenario
   instanceType: node
   sources:
   - properties:
       endSpecification:
         externalId: date_specification_default_end
         space: power_ops_instances
-      name: Fornebu 1 scenario
+      name: 15 min Fornebu 1 scenario
       startSpecification:
         externalId: date_specification_default_start
         space: power_ops_instances
@@ -18,14 +18,74 @@
   type:
     externalId: ShopScenarioSet
     space: power_ops_types
-- externalId: shop_scenario_set_fornebu_1_scenario_15_min_test
+- externalId: shop_scenario_set_15_min_fornebu_20_scenarios
   instanceType: node
   sources:
   - properties:
       endSpecification:
         externalId: date_specification_default_end
         space: power_ops_instances
-      name: Fornebu 1 scenario 15 min test
+      name: 15 min Fornebu 20 scenarios
+      startSpecification:
+        externalId: date_specification_default_start
+        space: power_ops_instances
+    source:
+      externalId: ShopScenarioSet
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet
+    space: power_ops_types
+- externalId: shop_scenario_set_15_min_fornebu_2_scenarios
+  instanceType: node
+  sources:
+  - properties:
+      endSpecification:
+        externalId: date_specification_default_end
+        space: power_ops_instances
+      name: 15 min Fornebu 2 scenarios
+      startSpecification:
+        externalId: date_specification_default_start
+        space: power_ops_instances
+    source:
+      externalId: ShopScenarioSet
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet
+    space: power_ops_types
+- externalId: shop_scenario_set_15_min_fornebu_3_scenarios
+  instanceType: node
+  sources:
+  - properties:
+      endSpecification:
+        externalId: date_specification_default_end
+        space: power_ops_instances
+      name: 15 min Fornebu 3 scenarios
+      startSpecification:
+        externalId: date_specification_default_start
+        space: power_ops_instances
+    source:
+      externalId: ShopScenarioSet
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenarioSet
+    space: power_ops_types
+- externalId: shop_scenario_set_fornebu_1_scenario
+  instanceType: node
+  sources:
+  - properties:
+      endSpecification:
+        externalId: date_specification_default_end
+        space: power_ops_instances
+      name: Fornebu 1 scenario
       startSpecification:
         externalId: date_specification_default_start
         space: power_ops_instances

--- a/toolkit/modules/resync/data_models/nodes/shared:BidConfigurationDayAhead.edge.yaml
+++ b/toolkit/modules/resync/data_models/nodes/shared:BidConfigurationDayAhead.edge.yaml
@@ -1,7 +1,7 @@
 - endNode:
-    externalId: shop_based_partial_bid_configuration_landet_2
+    externalId: shop_based_partial_bid_configuration_15_min_landet_2
     space: power_ops_instances
-  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_landet_2
+  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_15_min_landet_2
   instanceType: edge
   space: power_ops_instances
   startNode:
@@ -11,9 +11,9 @@
     externalId: BidConfiguration.partials
     space: power_ops_types
 - endNode:
-    externalId: shop_based_partial_bid_configuration_lien_krv_3
+    externalId: shop_based_partial_bid_configuration_15_min_lien_krv_3
     space: power_ops_instances
-  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_lien_krv_3
+  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_15_min_lien_krv_3
   instanceType: edge
   space: power_ops_instances
   startNode:
@@ -23,9 +23,9 @@
     externalId: BidConfiguration.partials
     space: power_ops_types
 - endNode:
-    externalId: shop_based_partial_bid_configuration_lund_3_step
+    externalId: shop_based_partial_bid_configuration_15_min_lund_3_step
     space: power_ops_instances
-  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_lund_3_step
+  externalId: bid_configuration_day_ahead_15_min_test_combination:shop_based_partial_bid_configuration_15_min_lund_3_step
   instanceType: edge
   space: power_ops_instances
   startNode:
@@ -47,9 +47,9 @@
     externalId: BidConfiguration.partials
     space: power_ops_types
 - endNode:
-    externalId: shop_based_partial_bid_configuration_landet_3
+    externalId: shop_based_partial_bid_configuration_15_min_landet_3
     space: power_ops_instances
-  externalId: bid_configuration_day_ahead_15_min_test_multi_scenario_3:shop_based_partial_bid_configuration_landet_3
+  externalId: bid_configuration_day_ahead_15_min_test_multi_scenario_3:shop_based_partial_bid_configuration_15_min_landet_3
   instanceType: edge
   space: power_ops_instances
   startNode:
@@ -59,9 +59,9 @@
     externalId: BidConfiguration.partials
     space: power_ops_types
 - endNode:
-    externalId: shop_based_partial_bid_configuration_lund_3
+    externalId: shop_based_partial_bid_configuration_15_min_lund_3
     space: power_ops_instances
-  externalId: bid_configuration_day_ahead_15_min_test_multi_scenario_3:shop_based_partial_bid_configuration_lund_3
+  externalId: bid_configuration_day_ahead_15_min_test_multi_scenario_3:shop_based_partial_bid_configuration_15_min_lund_3
   instanceType: edge
   space: power_ops_instances
   startNode:

--- a/toolkit/modules/resync/data_models/nodes/stavanger:ShopScenario.edge.yaml
+++ b/toolkit/modules/resync/data_models/nodes/stavanger:ShopScenario.edge.yaml
@@ -911,6 +911,66 @@
     externalId: ShopOutputTimeSeriesDefinition
     space: power_ops_types
 - endNode:
+    externalId: no2_buy_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_stavanger_price_plus_200_first_24h:no2_buy_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_stavanger_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: no2_sale_price_plus_200_first_24h
+    space: power_ops_instances
+  externalId: shop_scenario_stavanger_price_plus_200_first_24h:no2_sale_price_plus_200_first_24h
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_stavanger_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopAttributeMapping
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_market_price
+    space: power_ops_instances
+  externalId: shop_scenario_stavanger_price_plus_200_first_24h:shop_output_time_series_definition_market_price
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_stavanger_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_consumption
+    space: power_ops_instances
+  externalId: shop_scenario_stavanger_price_plus_200_first_24h:shop_output_time_series_definition_plant_consumption
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_stavanger_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
+    externalId: shop_output_time_series_definition_plant_production
+    space: power_ops_instances
+  externalId: shop_scenario_stavanger_price_plus_200_first_24h:shop_output_time_series_definition_plant_production
+  instanceType: edge
+  space: power_ops_instances
+  startNode:
+    externalId: shop_scenario_stavanger_price_plus_200_first_24h
+    space: power_ops_instances
+  type:
+    externalId: ShopOutputTimeSeriesDefinition
+    space: power_ops_types
+- endNode:
     externalId: no2_buy_price_plus_20_first_24h
     space: power_ops_instances
   externalId: shop_scenario_stavanger_price_plus_20_first_24h:no2_buy_price_plus_20_first_24h

--- a/toolkit/modules/resync/data_models/nodes/stavanger:ShopScenario.node.yaml
+++ b/toolkit/modules/resync/data_models/nodes/stavanger:ShopScenario.node.yaml
@@ -382,6 +382,30 @@
   type:
     externalId: ShopScenario
     space: power_ops_types
+- externalId: shop_scenario_stavanger_price_plus_200_first_24h
+  instanceType: node
+  sources:
+  - properties:
+      commands:
+        externalId: shop_commands_default
+        space: power_ops_instances
+      model:
+        externalId: shop_model_stavanger
+        space: power_ops_instances
+      name: Stavanger price plus 200 first 24h
+      source: resync
+      timeResolution:
+        externalId: shop_time_resolution_default
+        space: power_ops_instances
+    source:
+      externalId: ShopScenario
+      space: power_ops_core
+      type: view
+      version: '1'
+  space: power_ops_instances
+  type:
+    externalId: ShopScenario
+    space: power_ops_types
 - externalId: shop_scenario_stavanger_price_plus_20_first_24h
   instanceType: node
   sources:


### PR DESCRIPTION
## Description
Please describe the change you have made.

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [ ] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) and [_version.py](https://github.com/cognitedata/power-ops-sdk/blob/main/cognite/powerops/_version.py) per [semantic versioning](https://semver.org/). Version bump is not needed for resync or toolkit configuration changes as they do not affect the SDK itself.
