### PR TITLE
chore: configure git to ignore .dat files to avoid uploading license files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ demo/*
 */.venv.*
 .venv.*
 build.*
+*.dat


### PR DESCRIPTION
## Description

The SHOP license file is managed by toolkit but only gets uploaded to CDF when toolkit is run locally, not through CI/CD. To ensure the license file doesn't get committed adding `.dat` the default file extension from Sintef for license files.

## Checklist:
- [x] Tests added/updated.
- [x] Documentation updated.
- [x] Changelog updated in [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md).
- [x] Version bumped. If triggering a new release is desired, bump the version number in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) and [_version.py](https://github.com/cognitedata/power-ops-sdk/blob/main/cognite/powerops/_version.py) per [semantic versioning](https://semver.org/). Version bump is not needed for resync or toolkit configuration changes as they do not affect the SDK itself.
