### PR TITLE
chore: mark as deprecated to prepare for v1 release

### DIFF
--- a/cognite/powerops/cdf_labels.py
+++ b/cognite/powerops/cdf_labels.py
@@ -1,11 +1,14 @@
 from cognite.client.data_classes import LabelDefinition
 
+from cognite.powerops.utils.deprecation import deprecated_class
+
 try:
     from enum import StrEnum
 except ImportError:
     from strenum import StrEnum
 
 
+@deprecated_class
 class CDFLabel(StrEnum):
     @classmethod
     def as_label_definitions(cls) -> list[LabelDefinition]:
@@ -18,6 +21,7 @@ class CDFLabel(StrEnum):
         ]
 
 
+@deprecated_class
 class AssetLabel(CDFLabel):
     BENCHMARKING_CONFIGURATION = "benchmarking_configuration"
     BID_PROCESS_CONFIGURATION = "bid_process_configuration"
@@ -45,6 +49,7 @@ class AssetLabel(CDFLabel):
     WATERCOURSE = "watercourse"
 
 
+@deprecated_class
 class RelationshipLabel(CDFLabel):
     BID_MATRIX_GENERATOR_CONFIG_SEQUENCE = "relationship_to.bid_matrix_generator_config_sequence"
     BID_MATRIX_SEQUENCE = "relationship_to.bid_matrix_sequence"

--- a/cognite/powerops/client/_logger.py
+++ b/cognite/powerops/client/_logger.py
@@ -20,6 +20,8 @@ from typing import Union
 
 from loguru import logger
 
+from cognite.powerops.utils.deprecation import deprecated, deprecated_class
+
 __all__ = [
     "configure_debug_logging",
 ]
@@ -29,6 +31,7 @@ LoggingLevelT = Union[int, str]
 
 
 # https://github.com/Delgan/loguru#entirely-compatible-with-standard-logging
+@deprecated_class
 class InterceptHandler(logging.Handler):
     def emit(self, record):
         # Get corresponding Loguru level if it exists.
@@ -46,5 +49,6 @@ class InterceptHandler(logging.Handler):
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
 
 
+@deprecated
 def configure_debug_logging(level: LoggingLevelT) -> None:
     logging.basicConfig(handlers=[InterceptHandler()], level=level, force=True)

--- a/cognite/powerops/client/shop/data_classes/dayahead_trigger.py
+++ b/cognite/powerops/client/shop/data_classes/dayahead_trigger.py
@@ -5,9 +5,12 @@ from cognite.client.data_classes import Event, FileMetadata
 from pydantic import BaseModel, ConfigDict, field_validator
 from typing_extensions import Self
 
+from cognite.powerops.utils.deprecation import deprecated_class
+
 _SHOP_VERSION_FALLBACK = "15.3.3.2"
 
 
+@deprecated_class
 class DayaheadFunctionEvent:
     event_type: str = "POWEROPS_FUNCTION_CALL"
     external_id_prefix: str = "POWEROPS_FUNCTION_CALL_"
@@ -40,6 +43,7 @@ class DayaheadFunctionEvent:
         )
 
 
+@deprecated_class
 class PartialFunctionEvent(DayaheadFunctionEvent):
     plant: str = "bid:plant"
     method: str = "bid:bid_matrix_generation_method"
@@ -50,12 +54,14 @@ class PartialFunctionEvent(DayaheadFunctionEvent):
     plant_name_override: str = "bid:plant_name_override"
 
 
+@deprecated_class
 class TotalFunctionEvent(DayaheadFunctionEvent):
     portfolio: str = "bid:portfolio"
     bid_process_configuration_name: str = "bid:bid_process_configuration_name"
     relationship_label_to_trigger_event: str = "relationship_to.calculate_total_bid_matrix_event"
 
 
+@deprecated_class
 class DayaheadTriggerEvent:
     event_type: str = "POWEROPS_BID_PROCESS_FROM_PRERUNS"
     external_id_prefix: str = "POWEROPS_BID_PROCESS_"
@@ -109,12 +115,14 @@ class DayaheadTriggerEvent:
         )
 
 
+@deprecated_class
 class PrerunFileMetadata:
     plants: str = "shop:plants"
     price_scenario: str = "shop:price_scenario"
     _plants_delimiter: str = ","
 
 
+@deprecated_class
 class SHOPPreRunFile(BaseModel):
     """
     Represents a single shop run based on a pre-run file.
@@ -135,6 +143,7 @@ class SHOPPreRunFile(BaseModel):
         )
 
 
+@deprecated_class
 class Case(BaseModel):
     """
     Case definition based on a set of prerun files to run for certain plants that are used in the set of prerun files
@@ -147,6 +156,7 @@ class Case(BaseModel):
     pre_runs_external_id_prefix: str | None = None
 
 
+@deprecated_class
 class BidTimeFrame(BaseModel):
     """
     Used to dynamically specify what times to run the Dayahead bid process for in local time
@@ -194,6 +204,7 @@ class BidTimeFrame(BaseModel):
         return self.start_time_arrow.shift(days=1).format(self._date_string_format)
 
 
+@deprecated_class
 class DayaheadTrigger(BaseModel):
     """
     Contains the blueprint of a Dayahead workflow definition. Used to trigger one or more cases within a price area
@@ -228,6 +239,7 @@ class DayaheadTrigger(BaseModel):
     dayahead_configuration_external_id: str | None = "market_configuration_nordpool_dayahead"
 
 
+@deprecated_class
 class DayaheadWorkflowRun(BaseModel):
     """
     Return object when triggering a DayaheadTrigger workflow via the API.

--- a/cognite/powerops/client/shop/data_classes/shop_case.py
+++ b/cognite/powerops/client/shop/data_classes/shop_case.py
@@ -7,10 +7,12 @@ from pathlib import Path
 import yaml
 
 from cognite.powerops.client.shop.data_classes.shop_file_reference import SHOPFileReference, SHOPFileType
+from cognite.powerops.utils.deprecation import deprecated_class
 
 logger = logging.getLogger(__name__)
 
 
+@deprecated_class
 class SHOPCase:
     r"""
     Wrapper around YAML file for SHOP, describing a case.

--- a/cognite/powerops/client/shop/data_classes/shop_file_reference.py
+++ b/cognite/powerops/client/shop/data_classes/shop_file_reference.py
@@ -6,6 +6,7 @@ from typing import Any
 from cognite.client.data_classes import FileMetadata
 from typing_extensions import Self
 
+from cognite.powerops.utils.deprecation import deprecated_class
 from cognite.powerops.utils.identifiers import external_id_to_name
 
 try:
@@ -14,11 +15,13 @@ except ImportError:
     from strenum import StrEnum
 
 
+@deprecated_class
 class SHOPFileType(StrEnum):
     ASCII = "ascii"
     YAML = "yaml"
 
 
+@deprecated_class
 @dataclass
 class SHOPFileReference:
     external_id: str

--- a/cognite/powerops/client/shop/data_classes/shop_result_files.py
+++ b/cognite/powerops/client/shop/data_classes/shop_result_files.py
@@ -10,6 +10,7 @@ from typing import Generic, TypeVar, Union
 import yaml
 from cognite.client.data_classes import FileMetadata
 
+from cognite.powerops.utils.deprecation import deprecated_class
 from cognite.powerops.utils.helpers import get_dict_dot_keys, is_time_series_dict
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 FileContentTypeT = TypeVar("FileContentTypeT", bound=Union[str, dict])
 
 
+@deprecated_class
 class SHOPResultFile(abc.ABC, Generic[FileContentTypeT]):
     """Base class for handling a results file from SHOP."""
 
@@ -77,6 +79,7 @@ class SHOPResultFile(abc.ABC, Generic[FileContentTypeT]):
         raise NotImplementedError()
 
 
+@deprecated_class
 class SHOPLogFile(SHOPResultFile[str]):
     """
     Plain text result file (for SHOP messages and CPlex logs).
@@ -90,6 +93,7 @@ class SHOPLogFile(SHOPResultFile[str]):
         return self.data
 
 
+@deprecated_class
 class SHOPYamlFile(SHOPResultFile[dict]):
     """
     Yaml-formatted results file (for post_run.yaml file created by SHOP).

--- a/cognite/powerops/client/shop/data_classes/shop_results.py
+++ b/cognite/powerops/client/shop/data_classes/shop_results.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Union
 import pandas as pd
 
 from cognite.powerops.client.shop.data_classes.shop_result_files import SHOPLogFile, SHOPResultFile, SHOPYamlFile
+from cognite.powerops.utils.deprecation import deprecated_class
 
 if TYPE_CHECKING:
     from cognite.powerops.client.shop.data_classes import SHOPRun
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@deprecated_class
 class SHOPRunResult:
     def __init__(
         self,
@@ -101,6 +103,7 @@ class SHOPRunResult:
         return f"<SHOPRunResult status={self._shop_run.status}>"
 
 
+@deprecated_class
 class ObjectiveFunction:
     def __init__(
         self,

--- a/cognite/powerops/client/shop/data_classes/shop_run.py
+++ b/cognite/powerops/client/shop/data_classes/shop_run.py
@@ -16,6 +16,7 @@ from typing_extensions import Self
 
 from cognite.powerops.client.shop.data_classes.shop_case import SHOPCase
 from cognite.powerops.client.shop.data_classes.shop_file_reference import SHOPFileReference
+from cognite.powerops.utils.deprecation import deprecated_class
 
 try:
     from enum import StrEnum
@@ -23,18 +24,21 @@ except ImportError:
     from strenum import StrEnum
 
 
+@deprecated_class
 class SHOPRunStatus(StrEnum):
     SUCCESS = "success"
     FAILED = "failed"
     IN_PROGRESS = "in_progress"
 
 
+@deprecated_class
 class SHOPProcessEvents:
     finished: str = "POWEROPS_PROCESS_FINISHED"
     failed: str = "POWEROPS_PROCESS_FAILED"
     started: str = "POWEROPS_PROCESS_STARTED"
 
 
+@deprecated_class
 class SHOPRunEvent:
     event_type: str = "POWEROPS_SHOP_RUN"
     watercourse: str = "shop:watercourse"
@@ -51,6 +55,7 @@ class SHOPRunEvent:
     user_id: str = "user:identifier"
 
 
+@deprecated_class
 @dataclass
 class SHOPRun:
     """
@@ -312,6 +317,7 @@ class SHOPRun:
         return json.dumps(self.dump(), indent=4, default=str)
 
 
+@deprecated_class
 class SHOPRunList(UserList):
     """
     This represents a list of SHOP runs.

--- a/cognite/powerops/client/shop/data_classes/shop_run_event.py
+++ b/cognite/powerops/client/shop/data_classes/shop_run_event.py
@@ -8,9 +8,11 @@ from uuid import uuid4
 
 from cognite.client.data_classes import Event
 
+from cognite.powerops.utils.deprecation import deprecated_class
 from cognite.powerops.utils.helpers import str_datetime_to_ms
 
 
+@deprecated_class
 @dataclass
 class SHOPRunEvent:
     """

--- a/cognite/powerops/client/shop/data_classes/shop_run_filter.py
+++ b/cognite/powerops/client/shop/data_classes/shop_run_filter.py
@@ -7,8 +7,10 @@ from cognite.client.data_classes import filters
 from cognite.client.utils._time import datetime_to_ms
 
 from cognite.powerops.client.shop.data_classes.shop_run import SHOPRunEvent
+from cognite.powerops.utils.deprecation import deprecated, deprecated_class
 
 
+@deprecated
 def _custom_contains_any(
     keys: str | list[str],
     values: str | list[str],
@@ -22,6 +24,7 @@ def _custom_contains_any(
     return filters.Or(*[filters.Equals(keys, v) for v in values])
 
 
+@deprecated
 def _time_to_ms(time: str | arrow.Arrow | datetime.datetime) -> int:
     """Convert a time to milliseconds since epoch"""
     if isinstance(time, str):
@@ -34,6 +37,7 @@ def _time_to_ms(time: str | arrow.Arrow | datetime.datetime) -> int:
     raise TypeError(f"Could not convert {time} to milliseconds")
 
 
+@deprecated
 def _get_time_range_filter(
     property: str,
     after: str | arrow.Arrow | datetime.datetime | None = None,
@@ -53,6 +57,7 @@ def _get_time_range_filter(
     return filters.Range(property=property, **_range)
 
 
+@deprecated_class
 class SHOPRunFilter:
     def __init__(
         self,

--- a/cognite/powerops/utils/cdf/calls.py
+++ b/cognite/powerops/utils/cdf/calls.py
@@ -11,11 +11,13 @@ from cognite.client.exceptions import CogniteDuplicatedError
 from cognite.client.utils import ms_to_datetime
 from cognite.client.utils.useful_types import SequenceNotStr
 
+from cognite.powerops.utils.deprecation import deprecated
 from cognite.powerops.utils.require import require
 
 logger = logging.getLogger(__name__)
 
 
+@deprecated
 def retrieve_event(client: CogniteClient, external_id: str) -> Event:
     event = client.events.retrieve(external_id=external_id)
     if event is None:
@@ -42,6 +44,7 @@ def merge_dicts(*args: dict) -> dict:
     return merged
 
 
+@deprecated
 def retrieve_relationships_from_source_ext_id(
     client: CogniteClient,
     source_ext_id: str,
@@ -184,6 +187,7 @@ def retrieve_time_series_datapoints(  # type: ignore[no-untyped-def]
     return merge_dicts(time_series_start, time_series_end, time_series_range)
 
 
+@deprecated
 def create_event(client: CogniteClient, event: Event) -> None:
     try:
         client.events.create(event)

--- a/cognite/powerops/utils/cdf/resource_creation.py
+++ b/cognite/powerops/utils/cdf/resource_creation.py
@@ -4,9 +4,12 @@ from typing import Union
 
 from cognite.client.data_classes import Asset, Event, FileMetadata, Relationship, Sequence, TimeSeries
 
+from cognite.powerops.utils.deprecation import deprecated
+
 CDF_Resource = Union[Asset, TimeSeries, FileMetadata, Sequence, Event]
 
 
+@deprecated
 def simple_relationship(
     source: CDF_Resource,
     target: CDF_Resource,

--- a/cognite/powerops/utils/deprecation.py
+++ b/cognite/powerops/utils/deprecation.py
@@ -1,4 +1,5 @@
 import warnings
+from collections.abc import Callable
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -9,7 +10,7 @@ def deprecated_class(cls: type[T]) -> type[T]:
 
     def new_getattribute(self, name):  # type: ignore[no-untyped-def]
         warnings.warn(
-            f"\nWarning: Class `{cls.__name__}` is deprecated and will be removed.",
+            f"\nWarning: Class `{cls.__name__}` is deprecated and will be removed in the next major version.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -18,3 +19,17 @@ def deprecated_class(cls: type[T]) -> type[T]:
     cls.__getattribute__ = new_getattribute  # type: ignore[method-assign]
 
     return cls
+
+
+def deprecated(func: Callable) -> Callable:
+    """Decorator to mark functions as deprecated."""
+
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+        warnings.warn(
+            f"\nWarning: Function `{func.__name__}` is deprecated and will be removed in the next major version.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/cognite/powerops/utils/helpers.py
+++ b/cognite/powerops/utils/helpers.py
@@ -6,7 +6,10 @@ from typing import Any, Union
 
 from cognite.client.utils._time import datetime_to_ms
 
+from cognite.powerops.utils.deprecation import deprecated
 
+
+@deprecated
 def format_deep_diff_path(path: str) -> str:
     """
     Formats from deepdiff path to dot separated path
@@ -19,6 +22,7 @@ def format_deep_diff_path(path: str) -> str:
     return re.sub(r"['\[\]]", "", path.replace("][", ".").replace("root", ""))
 
 
+@deprecated
 def get_dict_dot_keys(data_dict: dict, dot_keys: str) -> Union[int, str, datetime.datetime, Any]:
     """
     Get for arbitrarily nested keys that are dot separated.
@@ -47,6 +51,7 @@ def get_dict_dot_keys(data_dict: dict, dot_keys: str) -> Union[int, str, datetim
     return reduce(operator.getitem, keys, data_dict)
 
 
+@deprecated
 def get_data_from_nested_dict(data_dict: dict, deep_diff_path: str) -> Union[int, str, datetime.datetime, Any]:
     dot_keys = format_deep_diff_path(deep_diff_path)
     return get_dict_dot_keys(data_dict, dot_keys)

--- a/cognite/powerops/utils/lookup.py
+++ b/cognite/powerops/utils/lookup.py
@@ -1,3 +1,7 @@
+from cognite.powerops.utils.deprecation import deprecated
+
+
+@deprecated
 def attr_lookup(value, attr_path):  # type: ignore[no-untyped-def]
     """
     Retrieve attributes from a nested structure, in a generator.
@@ -60,11 +64,13 @@ def attr_lookup(value, attr_path):  # type: ignore[no-untyped-def]
             yield from attr_lookup(getattr(value, sub_attr, None), attr_path[1:])
 
 
+@deprecated
 def each(items, attr_path):  # type: ignore[no-untyped-def]
     for item in items:
         yield from attr_lookup(item, attr_path)
 
 
+@deprecated
 def dict_get(value, attr_path):  # type: ignore[no-untyped-def]
     if isinstance(value, dict):
         yield from attr_lookup(value.get(attr_path[0]), attr_path[1:])
@@ -72,5 +78,6 @@ def dict_get(value, attr_path):  # type: ignore[no-untyped-def]
         yield None
 
 
+@deprecated
 def dict_values(value, attr_path):  # type: ignore[no-untyped-def]
     yield from attr_lookup(value.values(), attr_path)

--- a/cognite/powerops/utils/navigation.py
+++ b/cognite/powerops/utils/navigation.py
@@ -3,9 +3,12 @@ import inspect
 from collections.abc import Iterable, Sequence
 from typing import TypeVar
 
+from cognite.powerops.utils.deprecation import deprecated
+
 T_Type = TypeVar("T_Type", bound=type)
 
 
+@deprecated
 def all_subclasses(base: T_Type) -> list[T_Type]:
     """Returns a list (without duplicates) of all subclasses of a given class, sorted on import-path-name.
     Ignores classes not part of the main library, e.g. subclasses part of tests.
@@ -19,6 +22,7 @@ def all_subclasses(base: T_Type) -> list[T_Type]:
     )
 
 
+@deprecated
 def all_concrete_subclasses(base: T_Type) -> list[T_Type]:
     return [
         sub
@@ -27,6 +31,7 @@ def all_concrete_subclasses(base: T_Type) -> list[T_Type]:
     ]
 
 
+@deprecated
 def chunks(sequence: Sequence[T_Type], chunk_size: int) -> Iterable[Sequence[T_Type]]:
     """Yield successive n-sized chunks from lst."""
     for i in range(0, len(sequence), chunk_size):


### PR DESCRIPTION
## Description

Please describe the change you have made.

## Checklist

- [ ] Regenerate SDK with pygen (if changes made to the DM, see [CONTRIBUTING.md](../toolkit/CONTRIBUTING.md) for details)
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] [CHANGELOG.md](https://github.com/cognitedata/power-ops-sdk/blob/master/CHANGELOG.md) updated
- [ ] Version bumped in [pyproject.toml](https://github.com/cognitedata/power-ops-sdk/blob/master/pyproject.toml) and [_version.py](https://github.com/cognitedata/power-ops-sdk/blob/main/cognite/powerops/_version.py) per [semantic versioning](https://semver.org/)

**Note:** Version bump is not needed for any changes made outside the `cognite/powerops` folder as they do not affect the SDK itself.
